### PR TITLE
Allow alteration of the year labels on charts

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -9,3 +9,40 @@ $( document ).ready(function() {
   $('.zip-download-container').addClass('container');
 });
 
+$( document ).ready(function() {
+  opensdg.chartConfigAlter(function(config, info) {
+    var overrides = {
+      options: {
+        tooltips: {
+          callbacks: {
+            title: function(tooltipItem, data) {
+              var label = (Array.isArray(tooltipItem)) ? tooltipItem[0].label : tooltipItem.label;
+              return convertXAxisLabel(label);
+            }
+          }
+        },
+        scales: {
+          xAxes: [{
+            ticks: {
+              callback: function(value, index, values) {
+                return convertXAxisLabel(value);
+              }
+            },
+          }]
+        },
+      }
+    }
+
+    // Add these overrides onto the normal config.
+    $.extend(true, config, overrides);
+  });
+
+  function convertXAxisLabel(label) {
+    if (false) {
+      return 'insert some conversion here';
+    }
+    else {
+      return label;
+    }
+  }
+});


### PR DESCRIPTION
@pixerize This is an example of how to alter the year labels on charts. I'm also working on something similar for tables if possible. This might allow you to use something more compact for months/quarters, like "2018-Q3", "2018-Q4", etc, which would satisfy the alphabetical sorting.