### PR TITLE
Use altered year labels in table

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ languages:
 # Recommended: set this to a particular "release" of Open SDG. For example:
 #remote_theme: open-sdg/open-sdg@1.1.0
 #remote_theme: open-sdg/open-sdg@master
-remote_theme: brockfanning/open-sdg@standalone-indicators
+remote_theme: brockfanning/open-sdg@bosnia-feature-set
 
 # Replace this title as needed.
 title: custom.indicator_title

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -37,13 +37,24 @@ $( document ).ready(function() {
     $.extend(true, config, overrides);
   });
 
+  opensdg.tableConfigAlter(function(config, info) {
+    config.columnDefs = [
+      {
+        targets: 0,
+        render: function(data, type, row) {
+          return (type === 'display') ? convertXAxisLabel(data) : data;
+        }
+      }
+    ]
+  });
+
   function convertXAxisLabel(label) {
     let strVal = label.toString();
     let newLabel = strVal;
     if (strVal.length > 3 && strVal.charAt(1) == ")") {
       newLabel = strVal.substring(2);
     }
-    
+
     return newLabel;
   }
 });


### PR DESCRIPTION
@pixerize This should get the altered year labels into the table as well.

Also, this required another PR on the open-sdg project (https://github.com/open-sdg/open-sdg/pull/995) so I'm also now pointing to a separate branch on my fork that includes both the standalone indicators and this table alteration feature. As we add new features I'll merge them into that same branch: https://github.com/brockfanning/open-sdg/tree/bosnia-feature-set